### PR TITLE
update dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,20 +13,19 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ansi": "^0.2.1",
-    "dot": "^1.0.2",
-    "dustjs-helpers": "^1.2.0",
-    "dustjs-linkedin": "^2.3.5",
-    "handlebars": "^2.0.0-alpha.2",
-    "jade": "^1.3.1",
-    "marko": "^2.5.0",
-    "matcha": "^0.5.0",
-    "nunjucks": "^1.0.5",
-    "plates": "^0.4.9",
-    "raptor-async": "^1.0.0",
-    "raptor-polyfill": "^1.0.0",
-    "swig": "^1.3.2",
-    "uglify-js": "^2.4.13"
-  },
-  "devDependencies": {}
+    "ansi": "^0.3.0",
+    "dot": "^1.0.3",
+    "dustjs-helpers": "^1.7.2",
+    "dustjs-linkedin": "^2.7.2",
+    "handlebars": "^3.0.3",
+    "jade": "^1.11.0",
+    "marko": "^2.7.8",
+    "matcha": "^0.6.0",
+    "nunjucks": "^1.3.4",
+    "plates": "^0.4.11",
+    "raptor-async": "^1.1.2",
+    "raptor-polyfill": "^1.0.2",
+    "swig": "^1.4.2",
+    "uglify-js": "^2.4.24"
+  }
 }


### PR DESCRIPTION
I suggest running the results and publishing again using the same CPU / Memory setup.

also, it seems `doT` is taking lead now in `simple-1` test :)
