### PR TITLE
Benchmark simpler strings used by logging libraries

### DIFF
--- a/engines/es6.js
+++ b/engines/es6.js
@@ -1,5 +1,3 @@
-var template = require('lodash.template');
-
 module.exports = {
     name: 'es6',
     ext: 'es6.js',

--- a/engines/es6.js
+++ b/engines/es6.js
@@ -1,0 +1,13 @@
+var template = require('lodash.template');
+
+module.exports = {
+    name: 'es6',
+    ext: 'es6.js',
+    load: function(src, templatePath, templateName, callback) {
+        var App = require(templatePath);
+        callback(null, App);
+    },
+    render: function(template, data, callback) {
+        callback(null, template.exec(data));
+    }
+};

--- a/engines/lodash.js
+++ b/engines/lodash.js
@@ -1,0 +1,12 @@
+var template = require('lodash.template');
+
+module.exports = {
+    name: 'lodash',
+    ext: 'lodash',
+    render: function(template, data, callback) {
+        callback(null, template(data));
+    },
+    load: function(src, templatePath, templateName, callback) {
+        callback(null, template(src, { interpolate: /{([\s\S\.\-\_]+?)}/g }));
+    }
+};

--- a/templates/simple-0/data.json
+++ b/templates/simple-0/data.json
@@ -1,0 +1,7 @@
+{
+    "name": "George Washington",
+    "messageCount": 999,
+    "colors": ["red", "green", "blue", "yellow", "orange", "pink", "black", "white", "beige", "brown", "cyan", "magenta"],
+    "primary": true,
+    "buttonLabel": "Welcome to the wonderful world of templating engines!"
+}

--- a/templates/simple-0/template.dust
+++ b/templates/simple-0/template.dust
@@ -1,0 +1,1 @@
+Hello {name}! <strong>You have {messageCount} messages! {colors}

--- a/templates/simple-0/template.es6.js
+++ b/templates/simple-0/template.es6.js
@@ -1,0 +1,8 @@
+
+class BespokeTemplate {
+  exec(info) {
+    return `Hello {info.name}! <strong>You have {info.messageCount} messages! {info.colors}`;
+  }
+};
+
+module.exports = new BespokeTemplate();

--- a/templates/simple-0/template.lodash
+++ b/templates/simple-0/template.lodash
@@ -1,0 +1,1 @@
+Hello {name}! <strong>You have {messageCount} messages! {colors}

--- a/templates/simple-0/template.marko
+++ b/templates/simple-0/template.marko
@@ -1,0 +1,1 @@
+-- Hello ${data.name}! You have $!{data.messageCount} messages! {data.colors}

--- a/templating-benchmarks.js
+++ b/templating-benchmarks.js
@@ -303,7 +303,7 @@ function warmup(callback) {
     });
 }
 
-var only = null; //'if-expression';
+var only = process.env.ONLY || null;
 var fast = false;
 
 templateGroups.forEach(function(templateGroup) {


### PR DESCRIPTION
Thanks for this library! In preparation for `winston@3` I was doing research on the most performant way to perform simple string interpolation. I was surprised by the results. 

```
                      RUNTIME PERFORMANCE
                      ===================
                      simple-0
                     ✓ es6 »  673,216 op/s (fastest)
                   ✗ marko »  554,387 op/s (17.65% slower)
                  ✗ lodash »  259,616 op/s (61.44% slower)
                    ✗ dust »  244,852 op/s (63.63% slower)
```

This has greatly influenced the way the `winston@3` string interpolation API will be designed since bespoke ES6 Template Strings are actually the most performant option.